### PR TITLE
Bump dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3] - 2022-07-22
+
+### Changed
+
+- Bump dependencies
+
 ## [1.0.2] - 2021-11-25
 
 ### Changed


### PR DESCRIPTION
Release version to bump dependencies a bit. Basically to get rid of annoying Typescript version support warning.