### PR TITLE
upgrade to node v20 in workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,4 +4,4 @@ on: [push]
 
 jobs:
   test:
-    uses: cabify/javascript-actions/.github/workflows/tests.yml@main
+    uses: cabify/javascript-actions/.github/workflows/tests.yml@node-version-20


### PR DESCRIPTION
### Problem
We are getting some warnings when running jobs in workflows related to the node version. We are currently working with v18 but the recommendation is to run it under v20

### Solution
Update node version to recommended v20. We have opened an "experimental" branch in [javascript-actions](https://github.com/cabify/javascript-actions/tree/node-version-20) repo.

### Strategy
Update the repos that uses  uses `javascript-actions/.github/workflows/tests.yml` to this new branch.

Once we have all the repos running this version of workflow without errors we should merge this 