### PR TITLE
add pascal case and upper case to allowed import formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.1.1] - 2024-07-10
 
-- Updating naming convention for imports. Added `camelCase`, `PascalCase` and `UPPER_CASE`
-  
+- Updating naming convention for imports. Added `camelCase`, `PascalCase` and `UPPER_CASE`.
+
 ## [2.1.0] - 2024-06-20
 
 - Updating dependencies before migration to ESlint 9.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2024-07-10
+
+- Updating naming convention for imports. Added `camelCase`, `PascalCase` and `UPPER_CASE`
+  
 ## [2.1.0] - 2024-06-20
 
 - Updating dependencies before migration to ESlint 9.

--- a/configs/ts.js
+++ b/configs/ts.js
@@ -20,6 +20,10 @@ module.exports = {
         format: ['camelCase'],
       },
       {
+        selector: 'import',
+        format: ['camelCase', 'PascalCase'],
+      },      
+      {
         // This is the 'property' group values. For some reason `property` selector is not recogniced.
         selector: ['classProperty', 'objectLiteralProperty', 'typeProperty'],
         format: null,

--- a/configs/ts.js
+++ b/configs/ts.js
@@ -22,7 +22,7 @@ module.exports = {
       {
         selector: 'import',
         format: ['camelCase', 'PascalCase'],
-      },      
+      },
       {
         // This is the 'property' group values. For some reason `property` selector is not recogniced.
         selector: ['classProperty', 'objectLiteralProperty', 'typeProperty'],

--- a/configs/ts.js
+++ b/configs/ts.js
@@ -21,7 +21,7 @@ module.exports = {
       },
       {
         selector: 'import',
-        format: ['camelCase', 'PascalCase'],
+        format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
       },
       {
         // This is the 'property' group values. For some reason `property` selector is not recogniced.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cabify/eslint-config",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "ESLint config for Cabify Javascript projects",
   "scripts": {
     "build": "echo 'No build to perform'",


### PR DESCRIPTION
### Description
This change will allow us to add `imports` in PascalCase without showing errors