### PR TITLE
Use npm trusted publishing (OIDC) for package releases

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -15,6 +18,4 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: yarn install
       - run: yarn build
-      - run: npm publish --tag ${{ contains(github.ref_name,'beta') && 'beta' || 'latest' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --provenance --tag ${{ contains(github.ref_name,'beta') && 'beta' || 'latest' }}


### PR DESCRIPTION
## Summary

- Replace `NPM_TOKEN` secret with OIDC trusted publishing for npm
- Add `id-token: write` permission to enable provenance attestation
- Publish with `--provenance` flag for supply chain security
- No more token rotation needed every 90 days

## Setup done

Trusted publisher configured on npmjs.com for this repo/workflow (no environment).

## Test plan

- [x] Merge this PR
- [x] Create a new release to trigger the publish workflow
- [x] Verify the package is published successfully on npm with provenance badge
