### PR TITLE
refactor: move typescript-eslint to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     }
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^8.55.0",
     "confusing-browser-globals": "^1.0.10",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",
@@ -56,18 +55,19 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-simple-import-sort": "^12.1.1",
-    "globals": "^17.3.0",
-    "typescript-eslint": "^8.17.0"
+    "globals": "^17.3.0"
   },
   "peerDependencies": {
     "eslint": ">= 9.11.0",
-    "prettier": ">= 2.2.1"
+    "prettier": ">= 2.2.1",
+    "typescript-eslint": ">= 8.17.0"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "^6.0.3",
     "eslint": "10.0.1",
     "prettier": "3.8.1",
     "rollup-plugin-copy": "^3.5.0",
+    "typescript-eslint": "8.17.0",
     "vite": "^6.3.5",
     "vite-plugin-static-copy": "^3.2.0",
     "vite-plugin-top-level-await": "^1.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -687,20 +687,6 @@
     natural-compare "^1.4.0"
     ts-api-utils "^1.3.0"
 
-"@typescript-eslint/eslint-plugin@^8.55.0":
-  version "8.55.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.55.0.tgz#086d2ef661507b561f7b17f62d3179d692a0765f"
-  integrity sha512-1y/MVSz0NglV1ijHC8OT49mPJ4qhPYjiK08YUQVbIOyu+5k862LKUHFkpKHWu//zmr7hDR2rhwUm6gnCGNmGBQ==
-  dependencies:
-    "@eslint-community/regexpp" "^4.12.2"
-    "@typescript-eslint/scope-manager" "8.55.0"
-    "@typescript-eslint/type-utils" "8.55.0"
-    "@typescript-eslint/utils" "8.55.0"
-    "@typescript-eslint/visitor-keys" "8.55.0"
-    ignore "^7.0.5"
-    natural-compare "^1.4.0"
-    ts-api-utils "^2.4.0"
-
 "@typescript-eslint/parser@8.17.0":
   version "8.17.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.17.0.tgz#2ee972bb12fa69ac625b85813dc8d9a5a053ff52"
@@ -752,17 +738,6 @@
     debug "^4.3.4"
     ts-api-utils "^1.3.0"
 
-"@typescript-eslint/type-utils@8.55.0":
-  version "8.55.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.55.0.tgz#195d854b3e56308ce475fdea2165313bb1190200"
-  integrity sha512-x1iH2unH4qAt6I37I2CGlsNs+B9WGxurP2uyZLRz6UJoZWDBx9cJL1xVN/FiOmHEONEg6RIufdvyT0TEYIgC5g==
-  dependencies:
-    "@typescript-eslint/types" "8.55.0"
-    "@typescript-eslint/typescript-estree" "8.55.0"
-    "@typescript-eslint/utils" "8.55.0"
-    debug "^4.4.3"
-    ts-api-utils "^2.4.0"
-
 "@typescript-eslint/types@8.17.0":
   version "8.17.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.17.0.tgz#ef84c709ef8324e766878834970bea9a7e3b72cf"
@@ -812,7 +787,7 @@
     "@typescript-eslint/types" "8.17.0"
     "@typescript-eslint/typescript-estree" "8.17.0"
 
-"@typescript-eslint/utils@8.55.0", "@typescript-eslint/utils@^8.0.0":
+"@typescript-eslint/utils@^8.0.0":
   version "8.55.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.55.0.tgz#c1744d94a3901deb01f58b09d3478d811f96d619"
   integrity sha512-BqZEsnPGdYpgyEIkDC1BadNY8oMwckftxBT+C8W0g1iKPdeqKZBtTfnvcq0nf60u7MkjFO8RBvpRGZBPw4L2ow==
@@ -2343,11 +2318,6 @@ ignore@^5.1.1, ignore@^5.2.0, ignore@^5.3.1:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
-ignore@^7.0.5:
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
-  integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
-
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -3726,7 +3696,7 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.0.0"
     reflect.getprototypeof "^1.0.6"
 
-typescript-eslint@^8.17.0:
+typescript-eslint@8.17.0:
   version "8.17.0"
   resolved "https://registry.yarnpkg.com/typescript-eslint/-/typescript-eslint-8.17.0.tgz#fa4033c26b3b40f778287bc12918d985481b220b"
   integrity sha512-409VXvFd/f1br1DCbuKNFqQpXICoTB+V51afcwG1pn1a3Cp92MqAUges3YjwEdQ0cMUoCIodjVDAYzyD8h3SYA==


### PR DESCRIPTION
## Summary

- Move `typescript-eslint` from `dependencies` to `peerDependencies` (>= 8.17.0)
- Remove redundant `@typescript-eslint/eslint-plugin` from `dependencies`
- Add `typescript-eslint` to `devDependencies` for local development

## Motivation

When `typescript-eslint` is a direct dependency of the shared config, npm installs the version resolved by the config's lockfile (e.g. `8.35.1`). If a consumer pins a newer version (e.g. `8.59.3`), npm ends up with two copies and ERESOLVE conflicts due to incompatible peer dependency chains.

By making it a peer dependency, the consumer controls the exact version and npm can deduplicate the entire `@typescript-eslint/*` family into a single copy.

## Breaking change

Consumers that don't already have `typescript-eslint` as a direct devDependency will get an "unmet peer dependency" warning. Most projects already declare it — this just makes the requirement explicit.

## Test plan

- [x] `yarn install` resolves without errors
- [x] `yarn build` produces dist output successfully
- [ ] Verify consumer projects with `typescript-eslint` in devDeps install cleanly
- [ ] Communicate to frontend guild before releasing as a minor/major version bump